### PR TITLE
[WIP] Added wrapper for event triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ TemplateController('hello', {
     }
   },
 
+  // Events that the template can trigger is defined in trigger
+  trigger: {
+    customButtonEvent: 'button' // Triggered by calling this.trigger.customButtonEvent(optionalArguments);
+    customSpecialEvent: '.special' // Triggered by calling this.trigger.customSpecialEvent(optionalArguments);
+  }
+
   // These are added to the template instance but not exposed to the html
   private: {
     someProperty: 5,
@@ -235,6 +241,34 @@ TemplateController('hello', {
     sum(first, second) {
       return first + second;
     }
+  }
+});
+```
+
+### `trigger: { myEvent: myObject,… }`
+
+Blaze doesn't natively support event creation, but this TemplateController offers
+a solution (that doesn't require writing any jQuery code). To create a trigger
+you first initialize them in the config. This syntax doubles as a list of available
+events that a parent controller can listen to.
+
+```javascript
+TemplateController('hello', {
+
+  // Define event triggers
+  trigger: {
+    customSpecialEvent: '.special' // Triggered by calling this.trigger.customSpecialEvent(optionalArguments);
+  }
+});
+```
+
+After being initialized the triggers can be used by calling them as functions.
+
+```javascript
+TemplateController('hello', {
+
+  onRendered() {
+    this.trigger.customSpecialEvent();
   }
 });
 ```

--- a/source/template-controller.js
+++ b/source/template-controller.js
@@ -1,5 +1,5 @@
 const DEFAULT_API = [
-  'state', 'props', 'helpers', 'events', 'onCreated', 'onRendered', 'onDestroyed'
+  'state', 'props', 'helpers', 'events', 'trigger', 'onCreated', 'onRendered', 'onDestroyed'
 ];
 
 // Helpers

--- a/source/template-controller.js
+++ b/source/template-controller.js
@@ -27,6 +27,12 @@ const generateReactiveAccessor = function(defaultValue) {
   };
 };
 
+const generateTrigger = function(eventName, object) {
+  return function(args) {
+    Template.instance().$(object).trigger(eventName, args);
+  }
+};
+
 // Errors
 class TemplateNotFoundError extends ExtendableError {
   constructor(templateName) {
@@ -47,7 +53,7 @@ TemplateController = function(templateName, config) {
   if (!template) {
     throw new TemplateNotFoundError(templateName);
   }
-  let { state, props, helpers, events, onCreated, onRendered, onDestroyed } = config;
+  let { state, props, helpers, events, trigger, onCreated, onRendered, onDestroyed } = config;
 
   // Remove all standard api props fromt he config so we can have add the
   // rest to the template instance!
@@ -55,7 +61,7 @@ TemplateController = function(templateName, config) {
     delete config[apiProp];
   }
 
-  // State & private instance methods
+  // State & private instance methods, as well as event triggers
   template.onCreated(function() {
     if (state) {
       this.state = {};
@@ -68,6 +74,13 @@ TemplateController = function(templateName, config) {
     if (config.private) {
       for (let key of Object.keys(config.private)) {
         this[key] = config.private[key];
+      }
+    }
+    if (trigger) {
+      this.trigger = {};
+      // Setup the trigger as a set of function calls to wrap event triggers
+      for (let key of Object.keys(trigger)) {
+        this.trigger[key] = generateTrigger(key, trigger[key]);
       }
     }
   });


### PR DESCRIPTION
Sugar to remove jQuery code on event creation.

To enable events add:

``` javascript
trigger {
 myEvent: myObject;
}
```

and to triggering them write:

``` javascript
this.trigger.myEvent(myArgs);
```

These lines is equal to writing:

``` javascript
Template.current().$(myObject).trigger(myEvent, myArgs);
```

This feature will make it more transparent which event triggers the module offers, and will give a more Blaze like syntax for them.
