### PR TITLE
make props cleaning configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+## Next
+- Make it possible to configure the props cleaning operation of libs like SimpleSchema.
+
 ## 0.2.2
 - Fixes weird ecmascript errors in Meteor 1.2.x
 

--- a/README.md
+++ b/README.md
@@ -339,6 +339,21 @@ your template like this:
 This is also a best practice that we recommend to avoid strange bugs when
 publishing jQuery events.
 
+## Configuration
+
+### `TemplateController.setPropsCleanConfiguration(Object)`
+Enables you to configure the props cleaning operation of libs like SimpleSchema. Checkout [SimpleSchema clean docs](https://github.com/aldeed/meteor-simple-schema#cleaning-data) to
+see your options.
+
+Here is one example why `removeEmptyStrings: true` is the default config:
+
+
+```handlebars
+{{> button label=(i18n 'button_label') }}
+```
+`i18n` might initially return an empty string for your translation.
+This would cause an validation error because SimpleSchema removes empty strings by default when cleaning the data.
+
 ## Release History
 You can find the complete release history in the
 [changelog](https://github.com/meteor-space/template-controller/blob/master/CHANGELOG.md)

--- a/source/template-controller.js
+++ b/source/template-controller.js
@@ -57,6 +57,8 @@ const rootElementRequired = function() {
   return error;
 };
 
+let propsCleanConfiguration = {};
+
 // We have to make it a global to support Meteor 1.2.x
 TemplateController = function(templateName, config) {
   // Template reference
@@ -100,7 +102,7 @@ TemplateController = function(templateName, config) {
       this.autorun(() => {
         if (!props.validate) throw propertyValidatorRequired();
         let currentData = Template.currentData() || {};
-        props.clean(currentData);
+        props.clean(currentData, propsCleanConfiguration);
         try {
           props.validate(currentData);
         } catch (error) {
@@ -135,4 +137,8 @@ TemplateController = function(templateName, config) {
   if (onRendered) template.onRendered(onRendered);
   if (onDestroyed) template.onDestroyed(onDestroyed);
 
+};
+
+TemplateController.setPropsCleanConfiguration = (config) => {
+  propsCleanConfiguration = config;
 };


### PR DESCRIPTION
Small change, big effect – now we can configure the props cleaning operation of libs like SimpleSchema.
