### PR TITLE
Feature/getters and setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 Changelog
 =========
 
+## Next
+
+### Breaking Changes:
+- Introduces getters and setters for `props` and `state` properties, so now you
+  have to access them like real properties on an object instead of calling a
+  function. Now you have to do this
+  ```javascript
+  this.state.counter += 1;
+  ```
+  instead of
+  ```javascript
+  this.state.counter(this.state.counter() + 1);
+  ```
+### New Features:
+- You can dynamically add new reactive properties to `props` and `state` like this:
+  ```javascript
+  this.state.addProperty(key, defaultValue);
+  ```
+  or multiple at once:
+  ```javascript
+  this.state.addProperties({ key: value, ... });
+  ```
+
 ## 0.2.3
 - Make it possible to configure the props cleaning operation of libs like SimpleSchema.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ TemplateController('hello', {
   events: {
     'click button'() {
       // increment the counter when button is clicked
-      this.state.counter(this.state.counter() + 1);
+      this.state.counter += 1;
     }
   }
 
@@ -181,7 +181,7 @@ TemplateController('message_count', {
 ```
 
 … and you can access the value of `messageCount` anywhere in helpers etc. with
-`this.props.messageCount()`
+`this.props.messageCount`
 
 a parent template can provide the `messageCount` prop with standard Blaze:
 ```html
@@ -195,9 +195,9 @@ our component will throw a nice validation error.
 
 ### `state: { myProperty: defaultValue, … }`
 
-Each state property you define is turned into a `ReactiveVar` and wrapped into
-an accessor function, available via `this.state.myProperty()` as getter and
-`this.state.myProperty(newValue)` as setter. The reason why we are not using
+Each state property you define is turned into a `ReactiveVar` and you can get
+the value with `this.state.myProperty` and set it like a normal property
+`this.state.myProperty = newValue`. The reason why we are not using
 `ReactiveVar` directly is simple: we need a template helper to render it in
 our html template! So `TemplateController` actually adds a `state` template
 helper which returns `this.state` and thus you can render any state var in
@@ -207,13 +207,12 @@ your templates like this:
 You have clicked the button {{state.counter}} times.
 ```
 
-But you can also set the state var easily in your Js code like this:
+But you can also modify the state var easily in your Js code like this:
 
 ```javascript
 events: {
   'click button'() {
-    let incrementedValue = this.state.counter() + 1;
-    this.state.counter(incrementedValue);
+    this.state.counter += 1;
   }
 }
 ```
@@ -269,9 +268,8 @@ Here is a simple example:
 TemplateController('hello', {
   events: {
     'click button'() {
-      let incrementedValue = this.state.counter() + 1;
-      this.state.counter(incrementedValue);
-      this.triggerEvent('counterIncremented', incrementedValue);
+      this.state.counter += 1;
+      this.triggerEvent('counterIncremented', this.state.counter);
     }
   }
 });

--- a/source/template-controller.js
+++ b/source/template-controller.js
@@ -2,29 +2,36 @@ const DEFAULT_API = [
   'state', 'props', 'helpers', 'events', 'onCreated', 'onRendered', 'onDestroyed'
 ];
 
+class ReactiveObject {
+  constructor(properties = {}) {
+    this.addProperties(properties);
+  }
+  addProperty(key, defaultValue = null) {
+    const property = new ReactiveVar(defaultValue);
+    Object.defineProperty(this, key, {
+      get: () => { return property.get(); },
+      set: (value) => { property.set(value); }
+    });
+  }
+  addProperties(properties = {}) {
+    for (let key of Object.keys(properties)) {
+      this.addProperty(key, properties[key]);
+    }
+  }
+}
+
 // Helpers
-const withTemplateInstanceContext = function(handler) {
+const bindToTemplateInstance = function(handler) {
   return function() {
     return handler.apply(Template.instance(), arguments);
   };
 };
 
-const bindToTemplateInstance = function(handlers) {
+const bindAllToTemplateInstance = function(handlers) {
   for (let key of Object.keys(handlers)) {
-    handlers[key] = withTemplateInstanceContext(handlers[key]);
+    handlers[key] = bindToTemplateInstance(handlers[key]);
   }
   return handlers;
-};
-
-const generateReactiveAccessor = function(defaultValue) {
-  let value = new ReactiveVar(defaultValue);
-  return function(newValue) {
-    if (newValue !== undefined) {
-      value.set(newValue);
-    } else {
-      return value.get();
-    }
-  };
 };
 
 // Errors
@@ -77,11 +84,7 @@ TemplateController = function(templateName, config) {
   // State & private instance methods
   template.onCreated(function() {
     if (state) {
-      this.state = {};
-      // Setup the state as reactive vars
-      for (let key of Object.keys(state)) {
-        this.state[key] = generateReactiveAccessor(state[key]);
-      }
+      this.state = new ReactiveObject(state);
     }
     // Private
     if (config.private) {
@@ -98,7 +101,7 @@ TemplateController = function(templateName, config) {
 
     // Default values for props
     if (props) {
-      this.props = {};
+      this.props = new ReactiveObject();
       this.autorun(() => {
         if (!props.validate) throw propertyValidatorRequired();
         let currentData = Template.currentData() || {};
@@ -110,10 +113,10 @@ TemplateController = function(templateName, config) {
         }
         for (let key of Object.keys(currentData)) {
           let value = currentData[key];
-          if (!this.props[key]) {
-            this.props[key] = generateReactiveAccessor(value);
+          if (!this.props.hasOwnProperty(key)) {
+            this.props.addProperty(key, value, true);
           } else {
-            this.props[key](value);
+            this.props[key] = value;
           }
         }
       });
@@ -125,11 +128,11 @@ TemplateController = function(templateName, config) {
   if (!helpers) helpers = {};
   helpers.state = function() { return this.state; };
   helpers.props = function() { return this.props; };
-  template.helpers(bindToTemplateInstance(helpers));
+  template.helpers(bindAllToTemplateInstance(helpers));
 
   // Events
   if (events) {
-    template.events(bindToTemplateInstance(events));
+    template.events(bindAllToTemplateInstance(events));
   }
 
   // Lifecycle


### PR DESCRIPTION
### Breaking Changes:
- Introduces getters and setters for `props` and `state` properties, so now you
  have to access them like real properties on an object instead of calling a
  function. Now you have to do this

``` javascript
  this.state.counter += 1;
```

  instead of

``` javascript
this.state.counter(this.state.counter() + 1);
```
### New Features:
- You can dynamically add new reactive properties to `props` and `state` like this:

``` javascript
this.state.addProperty(key, defaultValue);
```

  or multiple at once:

``` javascript
this.state.addProperties({ key: value, ... });
```
